### PR TITLE
refactor: migrate to modern rust toolchain action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install and run Bulloak"
-        uses: "smol-ninja/bulloak-toolchain@staging"
+        uses: "smol-ninja/bulloak-toolchain@main"
         with:
           test-dir: test-workspace
 

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,6 @@
+printWidth: 120
+trailingComma: "all"
+overrides:
+  - files: "*.md"
+    options:
+      proseWrap: "always"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,20 @@
 MIT License
 
-Copyright (c) 2024 Sablier Labs Ltd
+Copyright (c) 2025 Shubham Yadav
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bulloak Toolchain
 
-This GitHub Action installs the [Bulloak](https://github.com/alexfertel/bulloak) toolchain and check that Solidity tests conform to BTT spec.
+This GitHub Action installs the [Bulloak](https://github.com/alexfertel/bulloak) toolchain and check that Solidity tests
+conform to BTT spec.
 
 ## Example workflow
 
@@ -20,7 +21,7 @@ jobs:
         uses: "actions/checkout@v4"
 
       - name: "Install and run Bulloak"
-        uses: "smol-ninja/bulloak-toolchain@v1"
+        uses: "smol-ninja/bulloak-toolchain@v2"
         with:
           skip-modifiers: "false"
           test-dir: "test-workspace"
@@ -28,14 +29,13 @@ jobs:
 
 ## Inputs
 
-| Name                 | Description                                                            | Default                                                    | Required? |
-| -------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------- | --------- |
-| `cache`              | Automatically configure Rust cache                                     | true                                                       | No        |
-| `cache-key`          | A custom key to identify the cache                                     | "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}" | No        |
-| `cache-restore-keys` | A custom key to identify the cache to restore                          | "${{ runner.os }}-cargo-"                                  | No        |
-| `save-always`        | Save the cache even if a prior step fails                              | true                                                       | No        |
-| `skip-modifiers`     | Whether to ignore modifiers declaration in the Solidity test contracts | false                                                      | No        |
-| `test-dir`           | The test directory which would usually be `test`                       |                                                            | Yes       |
+| Name               | Description                                                            | Default                                                    | Required? |
+| ------------------ | ---------------------------------------------------------------------- | ---------------------------------------------------------- | --------- |
+| `cache`            | Automatically configure Rust cache                                     | true                                                       | No        |
+| `cache-key`        | A custom key to identify the cache                                     | "${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}" | No        |
+| `cache-on-failure` | Save the cache even if a prior step fails                              | true                                                       | No        |
+| `skip-modifiers`   | Whether to ignore modifiers declaration in the Solidity test contracts | false                                                      | No        |
+| `test-dir`         | The test directory which would usually be `test`                       |                                                            | Yes       |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "bulloak-toolchain"
 description: "Install Bulloak and check that Solidity tests conform to BTT spec"
-author: "Sablier Labs Ltd"
+author: "Subham Yadav"
 
 branding:
   icon: "feather"
@@ -15,11 +15,7 @@ inputs:
     default: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     description: "A custom key to identify the cache"
     required: false
-  cache-restore-keys:
-    default: ${{ runner.os }}-cargo-
-    description: "A custom key to identify the cache to restore"
-    required: false
-  save-always:
+  cache-on-failure:
     default: "true"
     description: "Save the cache even if a prior step fails"
     required: false
@@ -40,29 +36,17 @@ runs:
   using: "composite"
   steps:
     - name: "Install Rust"
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
+        cache: ${{ inputs.cache }}
+        cache-key: ${{ inputs.cache-key }}
+        cache-on-failure: ${{ inputs.cache-on-failure }}
+        rustflags: ""
         toolchain: stable
 
-    - id: "cache-cargo"
-      name: "Setup Rust Caching"
-      if: ${{ inputs.cache == 'true' }}
-      uses: actions/cache@v4
-      with:
-        key: ${{ inputs.cache-key }}
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        restore-keys: ${{ inputs.cache-restore-keys }}
-        save-always: ${{ inputs.save-always }}
-
-    - name: "Install bulloak or use the cached version"
-      if: steps.cache-cargo.outputs.cache-hit != 'true'
+    - name: "Install bulloak"
       shell: bash
-      run: cargo install bulloak
+      run: cargo install bulloak --quiet
 
     - id: "version"
       name: "Print installed version"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: "bulloak-toolchain"
 description: "Install Bulloak and check that Solidity tests conform to BTT spec"
-author: "Subham Yadav"
+author: "Shubham Yadav"
 
 branding:
   icon: "feather"


### PR DESCRIPTION
Closes #10 and #11

Replace deprecated actions-rs/toolchain with actions-rust-lang/setup-rust-toolchain@v1:

- Remove manual cache configuration (now handled automatically)
- Update cache-related input parameters
- Simplify workflow with built-in rust-cache integration
- Add --quiet flag to cargo install for cleaner output
- Update CI workflow to use main branch reference

BREAKING CHANGE: cache-restore-keys input parameter removed as caching is now handled automatically by rust-cache

The version tag should be bumped to v2