### PR TITLE
fix: add input validation when required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
 
-  test-required-input:
+  revert-if-test-dir-is-missing:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,38 @@ jobs:
         run: |
           echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
 
+  test-nested-cargo-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out the repo"
+        uses: "actions/checkout@v4"
+
+      - name: "Create nested Cargo.lock"
+        run: |
+          mkdir -p node_modules/.pnpm/some-package/node_modules/dep
+          echo '[package]' > node_modules/.pnpm/some-package/node_modules/dep/Cargo.lock
+
+      - name: "Install and run Bulloak"
+        id: bulloak
+        uses: "./"
+        with:
+          test-dir: "test-workspace/integration/common"
+          version: "latest"
+
+      - name: "Verify resolved version"
+        env:
+          VERSION: ${{ steps.bulloak.outputs.bulloak-version }}
+        run: |
+          echo "Reported version: $VERSION"
+          if echo "$VERSION" | grep -qi "latest"; then
+            echo "::error::Version should be resolved, not 'latest'"
+            exit 1
+          fi
+          if ! echo "$VERSION" | grep -qE '[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Version '$VERSION' is not valid semver"
+            exit 1
+          fi
+
   revert-if-test-dir-is-missing:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,10 @@ jobs:
         continue-on-error: true
 
       - name: "Verify it failed"
+        env:
+          OUTCOME: ${{ steps.no-test-dir.outcome }}
         run: |
-          if [ "${{ steps.no-test-dir.outcome }}" != "failure" ]; then
+          if [ "$OUTCOME" != "failure" ]; then
             echo "::error::Expected failure when required input test-dir is missing"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: "Check out the repo"
         uses: "actions/checkout@v4"
 
+      - name: "Remove .tree files"
+        run: find . -name "*.tree" -delete
+
       - name: "Run action without test-dir"
         id: no-test-dir
         uses: "./"

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,19 @@ runs:
           exit 1
         fi
 
+    - id: resolve-version
+      name: "Resolve version"
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        if [ "$VERSION" == "latest" ]; then
+          RESOLVED=$(curl -s https://crates.io/api/v1/crates/bulloak | jq -r '.crate.max_version')
+          echo "version=$RESOLVED" >> $GITHUB_OUTPUT
+        else
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        fi
+
     - name: "Install Rust"
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
@@ -49,13 +62,12 @@ runs:
         toolchain: stable
 
     - id: cache-cargo
-      name: "Cache Cargo lockfile"
+      name: "Cache bulloak binary"
       if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@v4
       with:
-        key: ${{ runner.os }}-cargo-${{ inputs.version }}-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-bulloak-${{ steps.resolve-version.outputs.version }}
         path: ~/.cargo/bin/bulloak
-        restore-keys: ${{ runner.os }}-cargo-${{ inputs.version }}-
 
     - name: "Install cargo-binstall"
       if: steps.cache-cargo.outputs.cache-hit != 'true'
@@ -65,14 +77,10 @@ runs:
       if: steps.cache-cargo.outputs.cache-hit != 'true'
       shell: bash
       env:
-        VERSION: ${{ inputs.version }}
+        VERSION: ${{ steps.resolve-version.outputs.version }}
         DOCS_RS: "1"
       run: |
-        if [ "$VERSION" == "latest" ]; then
-          cargo binstall bulloak --no-confirm --log-level info
-        else
-          cargo binstall bulloak --version "$VERSION" --no-confirm --log-level info
-        fi
+        cargo binstall bulloak --version "$VERSION" --no-confirm --log-level info
 
     - id: "version"
       name: "Print installed version"

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,12 @@ runs:
           exit 1
         fi
 
+    - name: "Install Rust"
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache: false # Caching separately in the next step
+        toolchain: stable
+
     - id: resolve-version
       name: "Resolve version"
       shell: bash
@@ -49,17 +55,11 @@ runs:
         VERSION: ${{ inputs.version }}
       run: |
         if [ "$VERSION" == "latest" ]; then
-          RESOLVED=$(curl -s https://crates.io/api/v1/crates/bulloak | jq -r '.crate.max_version')
+          RESOLVED=$(cargo search bulloak --limit 1 2>/dev/null | head -1 | awk -F'"' '{print $2}')
           echo "version=$RESOLVED" >> $GITHUB_OUTPUT
         else
           echo "version=$VERSION" >> $GITHUB_OUTPUT
         fi
-
-    - name: "Install Rust"
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        cache: false # Caching separately in the next step
-        toolchain: stable
 
     - id: cache-cargo
       name: "Cache bulloak binary"

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,17 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: "Validate inputs"
+      shell: bash
+      env:
+        TEST_DIR: ${{ inputs.test-dir }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        if [ -z "$TEST_DIR" ]; then
+          echo "::error::Required input 'test-dir' is missing"
+          exit 1
+        fi
+
     - name: "Install Rust"
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:

--- a/action.yml
+++ b/action.yml
@@ -46,14 +46,21 @@ runs:
         path: ~/.cargo/bin/bulloak
         restore-keys: ${{ runner.os }}-cargo-${{ inputs.version }}-
 
+    - name: "Install cargo-binstall"
+      if: steps.cache-cargo.outputs.cache-hit != 'true'
+      uses: cargo-bins/cargo-binstall@main
+
     - name: "Install bulloak"
       if: steps.cache-cargo.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        DOCS_RS: "1"
       run: |
-        if [ "${{ inputs.version }}" == "latest" ]; then
-          cargo install bulloak --quiet
+        if [ "$VERSION" == "latest" ]; then
+          cargo binstall bulloak --no-confirm --log-level info
         else
-          cargo install bulloak --version ${{ inputs.version }} --quiet
+          cargo binstall bulloak --version "$VERSION" --no-confirm --log-level info
         fi
 
     - id: "version"


### PR DESCRIPTION
Closes #17 and https://github.com/smol-ninja/bulloak-toolchain/issues/16

## Changelog

1. Add a input validation step before installing Rust.
2. Replace `cargo install` with `cargo binstall` to download pre-compiled binaries from GH releases when available.
3. Add a new `revert-if-test-dir-is-missing` job that asserts that without `test-dir`, the action fails.